### PR TITLE
Add arduino-cli-kill-arduino-connection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The following keybindings are provided out of the box.
 | Create new sketch       | `C-c C-a n` |
 | Install a Library       | `C-c C-a i` |
 | Uninstall a Library     | `C-c C-a u` |
+| Kill Arduino Connection | `C-c C-a k` |
 
 
 ## Limitations

--- a/arduino-cli-mode.el
+++ b/arduino-cli-mode.el
@@ -144,7 +144,8 @@
   (let* ((cmd  (concat "arduino-cli " cmd " " (shell-quote-argument default-directory)))
          (cmd* (arduino-cli--add-flags 'compile cmd)))
     (save-some-buffers (not compilation-ask-about-save) (lambda () default-directory))
-    (compilation-start cmd* 'arduino-cli-compilation-mode)))
+    (setf arduino-cli--compilation-buffer
+          (compilation-start cmd* 'arduino-cli-compilation-mode))))
 
 (defun arduino-cli--message (cmd &rest path)
   "Run arduino-cli CMD in PATH (if provided) and print as message."
@@ -305,6 +306,19 @@
   (shell-command-to-string "arduino-cli core update-index")
   (arduino-cli--message "core upgrade"))
 
+(defun arduino-cli-kill-arduino-connection ()
+  "Kill any existing connection to an arduino."
+  (interactive)
+  (let ((comp-proc (get-buffer-process arduino-cli--compilation-buffer)))
+    (if comp-proc
+        (condition-case ()
+            (progn
+              (interrupt-process comp-proc)
+              (sit-for 1)
+              (delete-process comp-proc))
+          (error nil))
+      (message "No Arduino connection running!"))))
+
 ;; TODO change from compilation mode into other, non blocking mini-buffer display
 (defun arduino-cli-core-install ()
   "Find and install Arduino cores."
@@ -312,7 +326,8 @@
   (let* ((core (arduino-cli--search-cores))
          (cmd  (concat "arduino-cli core install " core)))
     (shell-command-to-string "arduino-cli core update-index")
-    (compilation-start cmd 'arduino-cli-compilation-mode)))
+    (setf arduino-cli--compilation-buffer
+          (compilation-start cmd 'arduino-cli-compilation-mode))))
 
 (defun arduino-cli-core-uninstall ()
   "Find and uninstall Arduino cores."
@@ -341,7 +356,8 @@
          (selection (arduino-cli--select libs "Library "))
          (cmd (concat "arduino-cli lib install " (shell-quote-argument selection))))
     (shell-command-to-string "arduino-cli lib update-index")
-    (compilation-start cmd 'arduino-cli-compilation-mode)))
+    (setf arduino-cli--compilation-buffer
+          (compilation-start cmd 'arduino-cli-compilation-mode))))
 
 (defun arduino-cli-lib-uninstall ()
   "Find and uninstall Arduino libraries."
@@ -381,6 +397,7 @@
     (define-key map (kbd "l") #'arduino-cli-board-list)
     (define-key map (kbd "i") #'arduino-cli-lib-install)
     (define-key map (kbd "u") #'arduino-cli-lib-uninstall)
+    (define-key map (kbd "k") #'arduino-cli-kill-arduino-connection)
     map)
   "Keymap for arduino-cli mode commands after `arduino-cli-mode-keymap-prefix'.")
 (fset 'arduino-cli-command-map arduino-cli-command-map)
@@ -390,6 +407,9 @@
     (define-key map arduino-cli-mode-keymap-prefix 'arduino-cli-command-map)
     map)
   "Keymap for arduino-cli mode.")
+
+(defvar arduino-cli--compilation-buffer nil
+  "The compilation buffer for the most recent compilation.")
 
 (easy-menu-define arduino-cli-menu arduino-cli-mode-map
   "Menu for arduino-cli."


### PR DESCRIPTION
*Problem*

Somehow, I found my arduino in a state that would not let the upload complete. I was getting repeated error messages: `avrdude: stk500_recv(): programmer is not responding`, and there was no way to stop the upload.

*Solution*

This adds a method to manually kill the connection to the arduino, using the same functionality used in the builtin compile.el.