### PR TITLE
support newer arduino-cli

### DIFF
--- a/arduino-cli-mode.el
+++ b/arduino-cli-mode.el
@@ -172,7 +172,7 @@
   "Get the default Arduino board, if available."
   (thread-first '()
     (arduino-cli--?map-put arduino-cli-default-fqbn 'fqbn)
-    (arduino-cli--?map-put arduino-cli-default-port 'address)))
+    (arduino-cli--?map-put (arduino-cli--?map-put '() arduino-cli-default-port 'address) 'port)))
 
 (defun arduino-cli--board ()
   "Get connected Arduino board."

--- a/arduino-cli-mode.el
+++ b/arduino-cli-mode.el
@@ -198,7 +198,10 @@
   "Get FQBN of BOARD.
 If BOARD has multiple matching_boards, the first one is used."
   (let* ((matching-boards (cdr (assoc 'matching_boards board)))
-         (first-matching-board (aref matching-boards 0))
+         ;; TODO: does the order here make sense?
+         (first-matching-board (if matching-boards
+                                   (aref matching-boards 0)
+                                 board))
          (fqbn (cdr (assoc 'fqbn first-matching-board))))
     fqbn))
 


### PR DESCRIPTION
thanks for creating this very useful mode!

i updated the code to match the current (0.34.2) arduino-cli JSON interface, although it seems these changes were introduced already in [0.19](https://arduino.github.io/arduino-cli/0.19/UPGRADING/). in particular,

- the `boards` key was renamed to `matching_boards`
- the `FQBN` key was lowercased to `fqbn`
- the `address` key was moved inside a `port` object

(recreated the PR to use a feature branch as the source, instead of my master. sorry for the spam)