### PR TITLE
support arduino-cli 1.0 json format

### DIFF
--- a/arduino-cli-mode.el
+++ b/arduino-cli-mode.el
@@ -194,8 +194,9 @@
 
 (defun arduino-cli--board ()
   "Get connected Arduino board."
-  (let* ((usb-devices     (arduino-cli--cmd-json "board list"))
-         (boards          (seq-filter #'arduino-cli--arduino? usb-devices))
+  (let* ((output          (arduino-cli--cmd-json "board list"))
+         (ports           (alist-get 'detected_ports output))
+         (boards          (seq-filter #'arduino-cli--arduino? ports))
          (boards-info     (seq-map (lambda (m) (thread-first (assoc 'boards m) cdr (seq-elt 0))) boards))
          (informed-boards (cl-mapcar (lambda (m n) (map-merge 'list m n)) boards boards-info))
          (selected-board  (arduino-cli--dispatch-board informed-boards))


### PR DESCRIPTION
hopefully fixes #11, which i only noticed after encountering and patching this myself.

i know i have commit rights, but i would like others to test this before merging. i only had an `esp8266:esp8266:nodemcuv2` board on hand, which has no `matching_boards` info, so i have to set `arduino-cli-default-fqbn` and `arduino-cli-default-port` manually, which skips some of the code dealing with arduino-cli output.

relevant change in arduino-cli: https://github.com/arduino/arduino-cli/pull/2407