### PR TITLE
support ANSI color output

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ You can enable the major flags from `arduino-cli` using similar enumerations.
 | `arduino-cli-warnings`               | `nil` (default), `'default`, `'more`, `'all` |
 | `arduino-cli-verbosity`              | `nil` (default), `'quiet`, `'verbose`        |
 | `arduino-cli-compile-only-verbosity` | `nil`, `t` (default)                         |
+| `arduino-cli-compile-color`          | `nil`, `t` (default)                         |
 
 If you want to automatically enable `arduino-cli-mode` on `.ino` files, you have to get [auto-minor-mode](https://github.com/joewreschnig/auto-minor-mode).
 Once that is installed, add the following to your init:

--- a/arduino-cli-mode.el
+++ b/arduino-cli-mode.el
@@ -97,11 +97,22 @@
   :group 'arduino-cli
   :type 'boolean)
 
+(defcustom arduino-cli-compile-color t
+  "If true (default), apply ANSI colors from compilation output."
+  :group 'arduino-cli
+  :type 'boolean)
+
 ;;; Internal functions
+(defun arduino-cli--compilation-filter ()
+  "Filter function for applying ANSI colors in compilation output."
+  (when arduino-cli-compile-color
+    (ansi-color-apply-on-region compilation-filter-start (point-max))))
+
 (define-compilation-mode arduino-cli-compilation-mode "arduino-cli-compilation"
   "Arduino-cli specific `compilation-mode' derivative."
   (setq-local compilation-scroll-output t)
-  (require 'ansi-color))
+  (require 'ansi-color)
+  (add-hook 'compilation-filter-hook #'arduino-cli--compilation-filter))
 
 (defun arduino-cli--?map-put (m v k)
   "Puts V in M under K when V, else return M."
@@ -122,6 +133,11 @@
   (when arduino-cli-warnings
     (concat " --warnings " (symbol-name arduino-cli-warnings))))
 
+(defun arduino-cli--compile-color ()
+  "Get the current compilation color setting."
+  (when (not arduino-cli-compile-color)
+    " --no-color"))
+
 (defun arduino-cli--general-flags ()
   "Add flags to CMD, if set."
   (concat (unless arduino-cli-compile-only-verbosity
@@ -131,7 +147,8 @@
   "Add flags to CMD, if set."
   (concat (arduino-cli--verify)
           (arduino-cli--warnings)
-          (arduino-cli--verbosity)))
+          (arduino-cli--verbosity)
+          (arduino-cli--compile-color)))
 
 (defun arduino-cli--add-flags (mode cmd)
   "Add general and MODE flags to CMD, if set."


### PR DESCRIPTION
implements proper interpretation of the ANSI color codes output by arduino-cli. this is enabled by default, but can be disabled by `(setq arduino-cli-compile-color nil)`, which also causes `--no-color` to be passed to arduino-cli commands.

i have been using this for about half a year now with no issues. i believe the original code resulted in color codes being output uninterpreted in the compilation window, which was a bit ugly. so this version should improve the behavior of both the colorized and colorless use cases :)