### PR TITLE
Add serial monitor functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The following keybindings are provided out of the box.
 | Install a Library       | `C-c C-a i` |
 | Uninstall a Library     | `C-c C-a u` |
 | Kill Arduino Connection | `C-c C-a k` |
+| Open Serial Monitor     | `C-c C-a m` |
+| Close Serial Monitor    | `C-c C-a M` |
 
 
 ## Limitations

--- a/arduino-cli-mode.el
+++ b/arduino-cli-mode.el
@@ -518,8 +518,10 @@ use `arduino-cli-monitor-default-baud-rate'."
            (async-shell-command-buffer 'confirm-kill-process)
            (shell-command-dont-erase-buffer t)
            (window (async-shell-command (format "arduino-cli monitor --port %s --config baudrate=%s"
-                                                port
-                                                (or (when monitor-baud-rate (prefix-numeric-value monitor-baud-rate)) arduino-cli-monitor-default-baud-rate))
+                                                (shell-quote-argument port)
+                                                (shell-quote-argument (format "%d"
+                                                                              (or (when monitor-baud-rate (prefix-numeric-value monitor-baud-rate))
+                                                                                  arduino-cli-monitor-default-baud-rate))))
                                         monitor-buffer)))
       (setf arduino-cli--monitor-buffer (window-buffer window)))))
 

--- a/arduino-cli-mode.el
+++ b/arduino-cli-mode.el
@@ -296,6 +296,10 @@ If BOARD has multiple matching_boards, the first one is used."
 (defun arduino-cli-compile-and-upload ()
   "Compile and upload Arduino project."
   (interactive)
+  (when (arduino-cli--serial-monitor-is-active)
+    (arduino-cli-stop-serial-monitor "to upload a sketch")
+    (add-hook 'compilation-finish-functions
+              #'arduino-cli--start-serial-monitor-callback))
   (let* ((board (arduino-cli--board))
          (fqbn  (if-let (fqbn (arduino-cli--board-fqbn board))
                     fqbn
@@ -309,6 +313,10 @@ If BOARD has multiple matching_boards, the first one is used."
 (defun arduino-cli-upload ()
   "Upload Arduino project."
   (interactive)
+  (when (arduino-cli--serial-monitor-is-active)
+    (arduino-cli-stop-serial-monitor "to upload a sketch")
+    (add-hook 'compilation-finish-functions
+              #'arduino-cli--start-serial-monitor-callback))
   (let* ((board (arduino-cli--board))
          (fqbn  (if-let (fqbn (arduino-cli--board-fqbn board))
                     fqbn
@@ -449,6 +457,88 @@ If BOARD has multiple matching_boards, the first one is used."
          )
     (find-file (alist-get (intern selection) output))))
 
+(defcustom arduino-cli-monitor-buffer-name "arduino cli monitor"
+  "The name for the arduino monitor buffer."
+  :group 'arduino-cli
+  :type 'string)
+
+(defvar arduino-cli--monitor-buffer nil
+  "The buffer for the monitor.")
+
+(defvar arduino-cli-monitor-default-baud-rate 115200
+  "The default baud rate to listen to for the serial monitor.
+
+It can be overridden by passing a prefix argument to
+`#'arduino-cli-start-serial-monitor'.
+
+This must match the value set in your sketch, in a line of code that
+looks like Serial.begin(115200).
+
+The arduino will only accept certain values. For more, see
+https://www.arduino.cc/reference/it/language/functions/communication/serial/begin/")
+
+(defun arduino-cli--serial-monitor-is-active ()
+  "Return t if the monitor is active, nil otherwise."
+  (not (not (process-live-p (get-buffer-process arduino-cli--monitor-buffer)))))
+
+(defun arduino-cli--start-serial-monitor-callback (compilation-buffer process-finish-status)
+  "Start the serial monitor, but also remove itself from `compilation-filter-hook'.
+
+It only runs when COMPILATION-BUFFER is `arduino-cli--compilation-buffer'."
+  (message "process-finish-status is %s" process-finish-status)
+  (when (and (eq compilation-buffer
+                 arduino-cli--compilation-buffer)
+             (string= process-finish-status
+                      "finished\n"))
+    (remove-hook 'compilation-filter-hook #'arduino-cli--start-serial-monitor-callback)
+    (arduino-cli-start-serial-monitor)))
+
+(defun arduino-cli-start-serial-monitor (&optional monitor-baud-rate)
+  "Start the arduino serial monitor.
+
+If MONITOR-BAUD-RATE is passed, use that as the baud rate. Otherwise,
+use `arduino-cli-monitor-default-baud-rate'."
+  (interactive "P")
+  (when (arduino-cli--serial-monitor-is-active)
+    (arduino-cli-stop-serial-monitor "to restart the serial monitor")
+    (while (arduino-cli--serial-monitor-is-active)
+      ;; arduino-cli-stop-serial-monitor calls kill-process, which
+      ;; kills the process asynchronously, so we need to wait for the
+      ;; process to actually end before restarting the monitor.
+      (sit-for 0.01)))
+  (let ((monitor-buffer (or (and (buffer-live-p arduino-cli--monitor-buffer)
+                                 arduino-cli--monitor-buffer)
+                            (get-buffer-create arduino-cli-monitor-buffer-name))))
+    (with-current-buffer monitor-buffer
+      (insert (format-time-string "\nStarting the monitor at %T\n\n")))
+    (let* ((board (arduino-cli--board))
+           (port (if-let (port (arduino-cli--board-address board))
+                     port
+                   (error "ERROR: No port specified")))
+           (async-shell-command-buffer 'confirm-kill-process)
+           (shell-command-dont-erase-buffer t)
+           (window (async-shell-command (format "arduino-cli monitor --port %s --config baudrate=%s"
+                                                port
+                                                (or (when monitor-baud-rate (prefix-numeric-value monitor-baud-rate)) arduino-cli-monitor-default-baud-rate))
+                                        monitor-buffer)))
+      (setf arduino-cli--monitor-buffer (window-buffer window)))))
+
+(defun arduino-cli-stop-serial-monitor (&optional reason)
+  "Stop the arduino serial monitor.
+
+If provided, REASON is printed in a message in the buffer."
+  (interactive)
+  (let ((arduino-monitor-process (get-buffer-process arduino-cli--monitor-buffer)))
+    (when (and (bufferp arduino-cli--monitor-buffer)
+               (process-live-p arduino-monitor-process))
+      (kill-process arduino-monitor-process)
+      (with-current-buffer arduino-cli--monitor-buffer
+        (insert (format "\nStopped serial monitor %sat %s...\n\n"
+                         (if reason
+                             (concat reason " ")
+                           "")
+                         (format-time-string "%T")))))))
+
 ;;; Minor mode
 (defvar arduino-cli-command-map
   (let ((map (make-sparse-keymap)))
@@ -460,6 +550,8 @@ If BOARD has multiple matching_boards, the first one is used."
     (define-key map (kbd "i") #'arduino-cli-lib-install)
     (define-key map (kbd "u") #'arduino-cli-lib-uninstall)
     (define-key map (kbd "k") #'arduino-cli-kill-arduino-connection)
+    (define-key map (kbd "m") #'arduino-cli-start-serial-monitor)
+    (define-key map (kbd "M") #'arduino-cli-stop-serial-monitor)
     map)
   "Keymap for arduino-cli mode commands after `arduino-cli-mode-keymap-prefix'.")
 (fset 'arduino-cli-command-map arduino-cli-command-map)

--- a/arduino-cli-mode.el
+++ b/arduino-cli-mode.el
@@ -482,15 +482,16 @@ https://www.arduino.cc/reference/it/language/functions/communication/serial/begi
   (not (not (process-live-p (get-buffer-process arduino-cli--monitor-buffer)))))
 
 (defun arduino-cli--start-serial-monitor-callback (compilation-buffer process-finish-status)
-  "Start the serial monitor, but also remove itself from `compilation-filter-hook'.
+  "Start the serial monitor and remove itself from `compilation-finish-functions'.
 
-It only runs when COMPILATION-BUFFER is `arduino-cli--compilation-buffer'."
-  (message "process-finish-status is %s" process-finish-status)
+It only runs when COMPILATION-BUFFER is
+`arduino-cli--compilation-buffer', and PROCESS-FINISH-STATUS is
+\"finished\n\", which is what the arduino reports."
   (when (and (eq compilation-buffer
                  arduino-cli--compilation-buffer)
              (string= process-finish-status
                       "finished\n"))
-    (remove-hook 'compilation-filter-hook #'arduino-cli--start-serial-monitor-callback)
+    (remove-hook 'compilation-finish-functions #'arduino-cli--start-serial-monitor-callback)
     (arduino-cli-start-serial-monitor)))
 
 (defun arduino-cli-start-serial-monitor (&optional monitor-baud-rate)

--- a/arduino-cli-mode.el
+++ b/arduino-cli-mode.el
@@ -510,7 +510,7 @@ use `arduino-cli-monitor-default-baud-rate'."
                                  arduino-cli--monitor-buffer)
                             (get-buffer-create arduino-cli-monitor-buffer-name))))
     (with-current-buffer monitor-buffer
-      (insert (format-time-string "\nStarting the monitor at %T\n\n")))
+      (insert (format-time-string "\nStarting the monitor at %T...\nTo stop it, press C-c C-c, or run arduino-cli-stop-serial-monitor.\n\n")))
     (let* ((board (arduino-cli--board))
            (port (if-let (port (arduino-cli--board-address board))
                      port


### PR DESCRIPTION
This commit adds functionality for arduino's serial monitor, including sending input from the buffer to the arduino (by typing something and pressing enter). This helps with debugging or interactive applications.

If the serial monitor is on when an upload happens, this code handles stopping the serial monitor before the upload, and restarting it after -- but only restarting if the upload succeeds. It reuses the same buffer for the monitor, so the history is shown.

**New keybindings in the keymap:**
* `m`: start the monitor. This handles stopping the monitor if it's open.
* `M`: stop the monitor.

**Future changes:**
1. Because the keybindings are in the regular keymap, they don't work inside the monitor buffer. This will be a future change I would like to make, but I don't think it's necessary to merge this in.
2. Only allow the user to provide input on the last line. Right now, any line is editable, and when you press enter, the whole line will be sent, even if that line was previously output.