### PR TITLE
Allow for default-directory to start with ~

### DIFF
--- a/arduino-cli-mode.el
+++ b/arduino-cli-mode.el
@@ -163,7 +163,7 @@
 
 (defun arduino-cli--compile (cmd)
   "Run arduino-cli CMD in 'arduino-cli-compilation-mode."
-  (let* ((cmd  (concat "arduino-cli " cmd " " (shell-quote-argument default-directory)))
+  (let* ((cmd  (concat "arduino-cli " cmd " " (shell-quote-argument (expand-file-name default-directory))))
          (cmd* (arduino-cli--add-flags 'compile cmd)))
     (save-some-buffers (not compilation-ask-about-save) (lambda () default-directory))
     (setf arduino-cli--compilation-buffer
@@ -171,11 +171,11 @@
 
 (defun arduino-cli--message (cmd &rest path)
   "Run arduino-cli CMD in PATH (if provided) and print as message."
-  (let* ((default-directory (shell-quote-argument (if path (car path) default-directory)))
+  (let* ((default-directory (expand-file-name (if path (car path) default-directory)))
          (cmd  (concat "arduino-cli " cmd))
          (cmd* (arduino-cli--add-flags 'message cmd))
          (out  (shell-command-to-string cmd*)))
-    (message out)))
+    (message (string-trim out))))
 
 (defun arduino-cli--arduino? (usb-device)
   "Return USB-DEVICE if it is an Arduino, nil otherwise."


### PR DESCRIPTION
This commit contains some changes I made that enable arduino-cli-mode to work on Linux Mint 22.1 when the sketch's default directory name starts with ~.  The README.md says that arduino-cli-mode was tested on MacOS; unfortunately I don't have a MacOS system that I can test these changes against.

A buffer's default-directory may start with ~, as documented in the output of `(describe-variable 'default-directory)`, which starts with the following lines [edited]:
```
default-directory is a variable defined in ‘C source code’.

Its value is
"~/.arduino15/RemoteSketchbook/ArduinoCloud/[...]/NM_RSSI_list/" Local in buffer NM_RSSI_list.ino; global value is nil

Name of default directory of current buffer.
It should be an absolute directory name; on GNU and Unix systems, these names start with "/" or "~" and end with "/". 
```

A default-directory that starts with ~ causes `arduino-cli-compile` to fail as shown in the contents of the `*arduino-cli-compilation*` buffer [edited]:
```
-*- mode: arduino-cli-compilation; default-directory: "~/.arduino15/RemoteSketchbook/ArduinoCloud/[...]/NM_RSSI_list/" -*- arduino-cli-compilation started at Wed Apr  9 20:07:31

arduino-cli compile --fqbn esp8266:esp8266:nodemcuv2 \~/.arduino15/RemoteSketchbook/ArduinoCloud/[...]/NM_RSSI_list/ -t --warnings all Can't open sketch: no such file or directory: /home/tdw/.arduino15/RemoteSketchbook/ArduinoCloud/[...]/NM_RSSI_list/~/.arduino15/RemoteSketchbook/ArduinoCloud/[...]/NM_RSSI_list

arduino-cli-compilation exited abnormally with code 1 at Wed Apr  9 20:07:32
```
The reason `arduino-cli-compilation` fails is that a leading ~ in default-directory is quoted by `shell-quote-argument` (as seen above) giving a non-existent directory name.  The fix is to remove any leading ~ using `expand-file-name`.

With this change, `arduino-cli-compilation` now behaves as expected:
```
-*- mode: arduino-cli-compilation; default-directory: "~/.arduino15/RemoteSketchbook/ArduinoCloud/[...]/NM_RSSI_list/" -*- arduino-cli-compilation started at Wed Apr  9 20:37:05

arduino-cli compile --fqbn esp8266:esp8266:nodemcuv2 /home/tdw/.arduino15/RemoteSketchbook/ArduinoCloud/[...]/NM_RSSI_list/ -t --warnings all [...]
```

A default-directory that starts with tilde also causes `arduino-cli--message` to fail, eg as seen with `arduino-cli-board-list`, which fails with the message:
```
shell-command: Setting current directory: No such file or directory, \~/.arduino15/RemoteSketchbook/ArduinoCloud/[...]/NM_RSSI_list/
```

The fix is similar: `expand-file-name` the default-directory (or provided directory) before using it.  I have also deleted the `shell-quote-argument` as the default-directory isn't passed to a shell. If you leave the `shell-quote-argument`, then `arduino-cli-board-list` with a sketch called "space star*" gives the following error:
```
shell-command: Setting current directory: No such file or directory, /home/tdw/space\ star\*/
```

With the changes so far, `arduino-cli-board-list` now gives the following message:
```
Port         Protocol Type              Board Name FQBN Core
/dev/ttyUSB0 serial   Serial Port (USB) Unknown


```
(note blank lines at the bottom).  All the commands that use `arduino-cli--message` show the blank lines at the bottom, so I have added a `string-trim` to remove them.