### PR TITLE
Use (message "%s" STR) idiom in case STR contains special chars.

### DIFF
--- a/arduino-cli-mode.el
+++ b/arduino-cli-mode.el
@@ -177,7 +177,7 @@ PATH should be an absolute directory name."
          (cmd  (concat "arduino-cli " cmd))
          (cmd* (arduino-cli--add-flags 'message cmd))
          (out  (shell-command-to-string cmd*)))
-    (message (string-trim out))))
+    (message "%s" (string-trim out))))
 
 (defun arduino-cli--arduino? (usb-device)
   "Return USB-DEVICE if it is an Arduino, nil otherwise."


### PR DESCRIPTION
In `arduino-cli--message`, the string that is displayed using `message` contains the output of an `arduino-cli` command, so we can't guarantee it won't contain any characters (such as %) that are special when used in the first argument of `message`, which is the format-string.

BTW, `message` is also used in `arduino-cli-kill-arduino-connection`, but there the string is a constant, and doesn't contain any special characters.

See
https://www.gnu.org/software/emacs/manual/html_node/elisp/Displaying-Messages.html .