### PR TITLE
Make declared types of user options match their documentation.

### DIFF
--- a/arduino-cli-mode.el
+++ b/arduino-cli-mode.el
@@ -72,38 +72,65 @@
 ;; values are passed to the shell as part of an arduino-cli command
 ;; line.
 
+;; Simple FQBNs have the format <vendor>:<architecture>:<board-id> but
+;; the full syntax is more complicated, and arduino-cli-mode simply
+;; passes the value to arduino-cli without parsing it in any way.
+
 (defcustom arduino-cli-default-fqbn nil
   "Default fqbn to use if board selection fails."
   :group 'arduino-cli
-  :type  'string)
+  :type  '(choice 
+	   (const :tag "No default (error message if board selection fails)" 
+		  nil)
+	   (string :tag "Fully qualified board name")))
+
+;; This is a string that is an "Upload port address, e.g.: COM3 or
+;; /dev/ttyACM2" (according to arduino-cli help message).
+;; It might be possible to validate it, but for now we just treat
+;; it as a string; arduino-cli-mode does not parse it, but simply
+;; passes the value to arduino-cli.
 
 (defcustom arduino-cli-default-port nil
   "Default port to use if board selection fails."
   :group 'arduino-cli
-  :type  'string)
+  :type  '(choice 
+	   (const :tag "No default (error message if board selection fails)" 
+		  nil)
+	   (string :tag "Port address")))
 
 (defcustom arduino-cli-verify nil
-  "Verify uploaded binary after the upload."
+  "Non-nil means verify uploaded binary after the upload."
   :group 'arduino-cli
   :type  'boolean)
 
 (defcustom arduino-cli-warnings nil
-  "Set GCC warning level, can be nil (default), 'default, 'more or 'all."
+  "Set GCC warning level, can be nil (none), `default', `more' or `all'."
   :group 'arduino-cli
-  :type  'boolean)
+  :type  '(choice (const :tag "--warnings default" default)
+		  (const :tag "--warnings more" more)
+		  (const :tag "--warnings all" all)
+		  (const :tag "No warnings flag; default level is \"none\"" nil)))
 
 (defcustom arduino-cli-verbosity nil
-  "Set arduino-cli verbosity level, can be nil (default), 'quiet or 'verbose."
+  "The verbosity flags (if any) to pass to arduino-cli commands.
+
+`quiet' passes --quiet to applicable arduino-cli commands
+(otherwise ignored).
+
+`verbose' passes --verbose to arduino-cli compile commands, 
+or all commands if arduino-cli-compile-only-verbosity is set to nil."
   :group 'arduino-cli
-  :type  'boolean)
+  :type  '(choice (const :tag "Quiet" quiet)
+		  (const :tag "Verbose" verbose)
+		  (const :tag "None" nil)))
 
 (defcustom arduino-cli-compile-only-verbosity t
-  "If true (default), only apply verbosity setting to compilation."
+  "Non-nil (default) means only apply verbosity setting to compilation."
   :group 'arduino-cli
   :type 'boolean)
 
 (defcustom arduino-cli-compile-color t
-  "If true (default), apply ANSI colors from compilation output."
+  "Non-nil (default) means apply ANSI colors from compilation output."
   :group 'arduino-cli
   :type 'boolean)
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,13 @@
+# Run tests for arduino-cli-mode
+#
+# Time-stamp: <2025-05-23 19:13:22 tdw>
+
+TESTS=customizable-variables-test.el
+
+all: $(TESTS)
+
+$(TESTS):
+	emacs --batch -L .. -l ert -l $@ -f ert-run-tests-batch-and-exit
+
+.PHONY: all $(TESTS)
+# Makefile ends here

--- a/test/customizable-variables-test.el
+++ b/test/customizable-variables-test.el
@@ -1,0 +1,161 @@
+;;; customizable-variables-test.el --- Tests for the user options of arduino-cli-mode -*- lexical-binding: t -*-
+;;
+;; Copyright © 2025
+;;
+;; Author: Tim Wilson
+;; Time-stamp: <2025-05-23 19:13:01 tdw>
+;; Created: 2025-04-16
+
+
+;; This file is NOT part of GNU Emacs.
+
+;;; License:
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; For a full copy of the GNU General Public License
+;; see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Test that the customizable variables accept their documented values
+;; (quietly) but generate a warning if set to an illegal value.
+
+;;; Code:
+
+(require 'ert)
+
+(require 'arduino-cli-mode)
+
+;;;; Internal functions
+
+;; The `with-warn-as-error' macro
+;;
+;; This macro is a bit like an opposite of `with-demoted-errors', but
+;; instead of turning errors into messages, it turns warnings into
+;; errors, and thus makes `warn' a function that never returns.
+
+(define-error 'warn-error "A warning")
+
+(defun warn-to-error (message &rest args)
+  "Like `warn', but signals a `warn-error' instead of displaying a warning."
+  (signal 'warn-error (apply #'format-message message args)))
+
+(defmacro with-stub (original-function replacement-function &rest body)
+  "Replace ORIGINAL-FUNCTION with REPLACEMENT-FUNCTION, then execute BODY.
+
+Like the arguments to `advice-add', ORIGINAL-FUNCTION should be quoted,
+and REPLACEMENT-FUNCTION should be function-quoted (eg with #')."
+  (declare (indent defun))
+  `(progn (advice-add ,original-function :override ,replacement-function)
+	  ;; Call the code.
+	  (unwind-protect
+	      (progn ,@body)
+	    ;; Clean up by restoring `warn'.
+	    (advice-remove ,original-function ,replacement-function))))
+
+(defmacro with-warn-as-error (&rest body)
+  "Like `progn', but any call to `warn' signals a warn-error."
+  `(with-stub 'warn #'warn-to-error ,@body))
+
+(defmacro customizable-variable-test (name option values &optional bad-values)
+  "Define test NAME of customizable variable OPTION which takes VALUES.
+
+Define a test that assigns to user OPTION (with `setopt') in turn:
+1. Its default value.
+2. Each value from the list VALUES.
+3. Each value from the list BAD-VALUES, 
+   which should cause a type-check warning."
+  
+  (declare (indent defun))
+  `(ert-deftest ,name ()
+     ;; TODO: Would be nice to make docstring include ,name or ,option,
+     ;; but I'm not sure if that's possible.
+     "Test values accepted by a customizable variable."
+
+     (let (,option)
+       ;; Sanity check
+       (should (custom-variable-p ',option))
+       (with-warn-as-error
+
+	;; Check default value.
+
+	(let ((default-value (default-value ',option)))
+	  (should (eq (setopt ,option default-value)
+		      default-value)))
+     
+	;; Check example(s) of documented values.
+
+	(mapc (lambda (value)
+		(should (eq (setopt ,option value)
+			    ,option)))
+	      ,values)
+	  
+	;; Check n example(s) outwith documented values.
+
+	(unless (null ,bad-values)
+	  (mapc (lambda (bad-value)
+		  (should-error (eq (setopt ,option bad-value)
+				    ,option)
+				:type 'warn-error))
+		,bad-values))))))
+
+
+;;;; The tests
+
+;;;;; arduino-cli-mode-keymap-prefix - no tests
+
+;;;;; Test arduino-cli-default-fqbn
+
+;; Simple FQBNs have the format <vendor>:<architecture>:<board-id> but
+;; the full syntax is more complicated, and arduino-cli-mode simply
+;; passes the value to arduino-cli.
+
+(customizable-variable-test
+  arduino-cli-default-fqbn-test arduino-cli-default-fqbn 
+  '("vendor:architecture:board_id") '(1))
+
+;;;;; Test arduino-cli-default-port
+
+;; This is a string that is an "Upload port address, e.g.: COM3 or
+;; /dev/ttyACM2" (according to arduino-cli help message).
+
+(customizable-variable-test
+  arduino-cli-default-port-test arduino-cli-default-port 
+  '("/dev/ttyACM2" "COM3") '(1))
+
+;;;;; Test arduino-cli-verify (a boolean)
+
+(customizable-variable-test
+  arduino-cli-verify-test arduino-cli-verify '(nil t))
+
+;;;;; Test arduino-cli-warnings (one of a number of documented symbols)
+
+(customizable-variable-test
+ arduino-cli-warnings-test arduino-cli-warnings '(nil default more all) '(1))
+
+;;;;; Test arduino-cli-verbosity (one of a number of documented symbols)
+
+(customizable-variable-test
+ arduino-cli-verbosity-test arduino-cli-verbosity '(nil quiet verbose) '(1))
+
+;;;;; Test arduino-cli-compile-only-verbosity (a boolean)
+
+(customizable-variable-test
+  arduino-cli-compile-only-verbosity-test arduino-cli-compile-only-verbosity 
+  '(nil t))
+
+;;;;; Test arduino-compile-colour (a boolean)
+
+(customizable-variable-test
+  arduino-cli-compile-color-test arduino-cli-compile-color '(nil t))
+
+;; customizable-variables-test.el ends here


### PR DESCRIPTION
Prior to the changes in this commit, setting some of arduino-cli-mode's user options to a documented legal value would generate a warning because the option's declared type did not accommodate all documented values.  This commit makes the declared types match the documented range of values (which also means you can use the Easy Customization Interface to set any legal value).

This commit affects the types of:

 - `arduino-cli-default-fqbn`: originally string, allow nil too

 - `arduino-cli-default-port`: originally string, allow nil too

 - `arduino-cli-warnings`: originally boolean, but instead of t allow the documented non-nil values of 'default, 'more, or 'all

 - `arduino-cli-verbosity`: originally boolean, but instead of t allow the documented non-nil values of 'quiet or 'verbose

The tests check that the user options can be assigned (examples of) all documented values without generating a warning.  

The simple makefile provides a way to run all the tests with `M-x compile`.  The makefile is structured to accommodate multiple files of tests, though I have only included one in this commit.